### PR TITLE
Export HeroID in benchmark service

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -20,7 +20,7 @@ type BenchmarkService struct {
 }
 
 type benchmarkParam struct {
-	heroID string `url:"hero_id"`
+	HeroID string `url:"hero_id"`
 }
 
 // Benchmark holds a collection of benchmarks for a hero.
@@ -49,7 +49,7 @@ type BenchmarkResult struct {
 // https://docs.opendota.com/#tag/benchmarks%2Fpaths%2F~1benchmarks%2Fget
 func (s *BenchmarkService) Benchmarks(heroID int) (Benchmark, *http.Response, error) {
 	param := &benchmarkParam{}
-	param.heroID = strconv.Itoa(heroID)
+	param.HeroID = strconv.Itoa(heroID)
 	benchmarks := new(Benchmark)
 	apiError := new(APIError)
 	resp, err := s.sling.New().QueryStruct(param).Receive(benchmarks, apiError)


### PR DESCRIPTION
Because HeroID is currently not exported it gets ignored (because it can't be read) when passed into the sling QueryStruct.

This fixes that so that it's visible :)